### PR TITLE
Make `src` an optional paramter

### DIFF
--- a/src/framer.mjs
+++ b/src/framer.mjs
@@ -70,11 +70,14 @@ class Framer {
   createIframe_() {
     const iframe = (this.iframe = document.createElement('iframe'));
 
-    iframe.setAttribute('src', this.src);
     iframe.setAttribute('width', '100%');
     iframe.setAttribute('scrolling', 'no');
     iframe.setAttribute('marginheight', '0');
     iframe.setAttribute('frameborder', '0');
+    
+    if (this.src) {
+      iframe.setAttribute('src', this.src);
+    }
 
     if (this.allowfullscreen) {
       iframe.setAttribute('allowfullscreen', '');


### PR DESCRIPTION
I'm using this to create a sandboxed iFrame that shouldn't have a `src`. I've tried to work within the constructor provided, but all the options are conflicting with my ability to inject content into it.

Things I've tried to get around the problem: 
- Not passing a `src` makes the iframe have `src="undefined"`
- Passing it a blank `src` makes the iframe have `src(unknown)`. 
- Passing it a `null` `src` makes the iframe have `src="null"`. 

I think the best thing to do is simply not set the attribute if it's not provided to the constructor. 

Happy to talk some more about my (admittedly a-typical)  use case  if you'd like.