### PR TITLE
Set name attribute to this.name, not empty name

### DIFF
--- a/src/framer.mjs
+++ b/src/framer.mjs
@@ -81,7 +81,7 @@ class Framer {
     }
 
     if (this.name) {
-      iframe.setAttribute('name', name);
+      iframe.setAttribute('name', this.name);
     }
 
     if (this.referrerpolicy) {


### PR DESCRIPTION
When setting iframe `name` attribute using `data-frame-name` set
attribute value using `this.name` to pull stored name value from class
instance rather than the empty variable `name`.